### PR TITLE
Feature/GitHub action

### DIFF
--- a/.github/workflows/append-contribution-guide.yml
+++ b/.github/workflows/append-contribution-guide.yml
@@ -1,0 +1,44 @@
+name: Append Contributor Guide to Issues
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  append-guide:
+    if: github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if label matches
+        id: label_check
+        run: |
+          echo "LABEL_MATCH=false" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "labeled" ]]; then
+            if [[ "${{ github.event.label.name }}" == "good first issue" || "${{ github.event.label.name }}" == "help wanted" ]]; then
+              echo "LABEL_MATCH=true" >> $GITHUB_ENV
+            fi
+          elif [[ "${{ github.event_name }}" == "opened" ]]; then
+            for label in "${{ toJson(github.event.issue.labels) }}"; do
+              if [[ "$label" == *"good first issue"* || "$label" == *"help wanted"* ]]; then
+                echo "LABEL_MATCH=true" >> $GITHUB_ENV
+              fi
+            done
+          fi
+
+      - name: Append Contributor Guide
+        if: env.LABEL_MATCH == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.issue.number;
+            const body = context.payload.issue.body || '';
+            const guideText = `\n\n---\n\n🆕 First-time contributor? Check out the [Contributor Getting Started Guide](https://yourproject.com/contributing)`;
+
+            if (!body.includes(guideText.trim())) {
+              const updatedBody = `${body}${guideText}`;
+              await github.rest.issues.update({
+                ...context.issue,
+                body: updatedBody
+              });
+            }

--- a/.github/workflows/append-contribution-guide.yml
+++ b/.github/workflows/append-contribution-guide.yml
@@ -1,44 +1,31 @@
-name: Append Contributor Guide to Issues
+name: Append Contributor Guide
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
+
+permissions:
+  issues: write
 
 jobs:
-  append-guide:
-    if: github.event.issue.state == 'open'
+  append-contributor-guide:
     runs-on: ubuntu-latest
-
+    if: >
+      github.event.label.name == 'good first issue' || 
+      github.event.label.name == 'help wanted'
     steps:
-      - name: Check if label matches
-        id: label_check
-        run: |
-          echo "LABEL_MATCH=false" >> $GITHUB_ENV
-          if [[ "${{ github.event_name }}" == "labeled" ]]; then
-            if [[ "${{ github.event.label.name }}" == "good first issue" || "${{ github.event.label.name }}" == "help wanted" ]]; then
-              echo "LABEL_MATCH=true" >> $GITHUB_ENV
-            fi
-          elif [[ "${{ github.event_name }}" == "opened" ]]; then
-            for label in "${{ toJson(github.event.issue.labels) }}"; do
-              if [[ "$label" == *"good first issue"* || "$label" == *"help wanted"* ]]; then
-                echo "LABEL_MATCH=true" >> $GITHUB_ENV
-              fi
-            done
-          fi
-
-      - name: Append Contributor Guide
-        if: env.LABEL_MATCH == 'true'
+      - name: Append contributor guide link
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issueNumber = context.issue.number;
             const body = context.payload.issue.body || '';
-            const guideText = `\n\n---\n\n🆕 First-time contributor? Check out the [Contributor Getting Started Guide](https://yourproject.com/contributing)`;
-
-            if (!body.includes(guideText.trim())) {
-              const updatedBody = `${body}${guideText}`;
+            const guide = '\n\n---\n\nFirst-time contributor? Check out the [Contributor Getting Started Guide](https://github.com/filiptrivan/spiderly?tab=readme-ov-file#getting-started-as-a-contributor)';
+            if (!body.includes('Contributor Getting Started Guide')) {
               await github.rest.issues.update({
-                ...context.issue,
-                body: updatedBody
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body + guide
               });
             }


### PR DESCRIPTION
Hi @filiptrivan,

This PR adds a GitHub Action that appends a contributor guide link to the body of newly labeled issues that have either the `good first issue` or `help wanted` label.

### How It Works
- Listens for issue label events
- If the label is `good first issue` or `help wanted`
- It appends this line (if not already present) to the issue body:

Closed #86 

Thank You!!
