### PR TITLE
Add separate email templates for login and registration verification

### DIFF
--- a/Spiderly.Security/Services/SecurityBusinessService.cs
+++ b/Spiderly.Security/Services/SecurityBusinessService.cs
@@ -157,10 +157,10 @@ namespace Spiderly.Security.Services
                 if (user == null)
                 {
                     string verificationCode = _jwtAuthManagerService.GenerateAndSaveRegistrationVerificationCode(registrationDTO.Email, registrationDTO.BrowserId);
+                    EmailVerifyUIDTO EmailTemplate = CreateRegistrationEmailTemplate(verificationCode);
 
                     try
-                    {
-                        EmailVerifyUIDTO EmailTemplate = CreateRegistrationEmailTemplate(verificationCode);
+                    {                        
                         await _emailingService.SendVerificationEmailAsync(registrationDTO.Email, EmailTemplate);
                     }
                     catch (Exception)

--- a/Spiderly.Security/Services/SecurityBusinessService.cs
+++ b/Spiderly.Security/Services/SecurityBusinessService.cs
@@ -69,7 +69,7 @@ namespace Spiderly.Security.Services
             });
 
             string verificationCode = _jwtAuthManagerService.GenerateAndSaveLoginVerificationCode(userEmail, userId, loginDTO.BrowserId);
-            EmailVerifyUIDTO EmailTemplate = CreateEmailTemplate(verificationCode);
+            EmailVerifyUIDTO EmailTemplate = CreateLoginEmailTemplate(verificationCode);
             try
             {
                 
@@ -82,7 +82,7 @@ namespace Spiderly.Security.Services
             }
         }
 
-         public virtual EmailVerifyUIDTO CreateEmailTemplate(string verificationCode)
+         public virtual EmailVerifyUIDTO CreateLoginEmailTemplate(string verificationCode)
          {
             return new EmailVerifyUIDTO
             {
@@ -160,7 +160,7 @@ namespace Spiderly.Security.Services
 
                     try
                     {
-                        EmailVerifyUIDTO EmailTemplate = CreateEmailTemplate(verificationCode);
+                        EmailVerifyUIDTO EmailTemplate = CreateRegistrationEmailTemplate(verificationCode);
                         await _emailingService.SendVerificationEmailAsync(registrationDTO.Email, EmailTemplate);
                     }
                     catch (Exception)
@@ -176,6 +176,15 @@ namespace Spiderly.Security.Services
             });
 
             return registrationResultDTO;
+        }
+
+        public virtual EmailVerifyUIDTO CreateRegistrationEmailTemplate(string verificationCode)
+        {
+            return new EmailVerifyUIDTO
+            {
+                Subject = SharedTerms.EmailAccountVerificationTitle,
+                Body = verificationCode
+            };
         }
 
         public async Task<AuthResultDTO> Register(VerificationTokenRequestDTO verificationRequestDTO)


### PR DESCRIPTION
Description:

This PR introduces two distinct email templates for login and registration verification processes to avoid confusion and improve clarity for users.

Changes Made:

Added CreateLoginTemplate and CreateRegistrationTemplate methods in SecurityBusinessService<TUser>.

Updated SendLoginVerificationEmail to use CreateLoginTemplate.

Updated SendRegistrationVerificationEmail to use CreateRegistrationTemplate.

Removed shared CreateEmailTemplate method (if unused elsewhere).

#23 Close

Thank You
Deepak Shirke

