### PR TITLE
Add diagnostic reporting for unhandled exceptions in source generators

### DIFF
--- a/Spiderly.SourceGenerators/Angular/NgBaseDetailsGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgBaseDetailsGenerator.cs
@@ -52,8 +52,14 @@ namespace Spiderly.SourceGenerators.Angular
             {
                 var (classesAndEntities, callingPath) = source;
                 var (classes, referencedClasses) = classesAndEntities;
-
-                Execute(classes, referencedClasses, callingPath, spc);
+                try
+                {
+                    Execute(classes, referencedClasses, callingPath, spc);
+                }
+                catch(Exception exception)
+                {
+                    Diagnostics.ReportException(spc, nameof(NgBaseDetailsGenerator), exception);
+                }
             });
         }
 

--- a/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
@@ -56,8 +56,16 @@ namespace Spiderly.SourceGenerators.Angular
             {
                 var (classesAndEntities, callingPath) = source;
                 var (classes, referencedClasses) = classesAndEntities;
-
-                Execute(classes, referencedClasses, callingPath, spc);
+               
+                try
+                {
+                    Execute(classes, referencedClasses, callingPath, spc);
+                }
+                catch (Exception exception) 
+                {
+                    Diagnostics.ReportException(spc, nameof(NgControllersGenerator), exception);
+                } 
+                
             });
         }
 
@@ -115,6 +123,7 @@ export class ApiGeneratedService extends ApiSecurityService {
 
         private static List<string> GetAngularHttpMethods(List<SpiderlyClass> controllerClasses, List<SpiderlyClass> currentAppEntities, List<SpiderlyClass> referencedProjectEntities, List<SpiderlyClass> referencedDTOClasses)
         {
+
             List<string> result = new();
             HashSet<string> alreadyAddedMethods = new HashSet<string>();
 

--- a/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
@@ -56,8 +56,15 @@ namespace Spiderly.SourceGenerators.Angular
             {
                 var (classesAndEntities, callingPath) = source;
                 var (classes, referencedClasses) = classesAndEntities;
-
-                Execute(classes, referencedClasses, callingPath, spc);
+                try
+                {
+                    Execute(classes, referencedClasses, callingPath, spc);
+                }
+                catch(Exception exception)
+                {
+                    Diagnostics.ReportException(spc, nameof(NgEntitiesGenerator), exception);
+                }
+                
             });
         }
 

--- a/Spiderly.SourceGenerators/Angular/NgEnumsGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgEnumsGenerator.cs
@@ -59,9 +59,16 @@ namespace Spiderly.SourceGenerators.Angular
 
             context.RegisterImplementationSourceOutput(combined, static (spc, source) =>
             {
-                var (((enums, classDeclarations), referencedProjectClasses), callingPath) = source;
+            var (((enums, classDeclarations), referencedProjectClasses), callingPath) = source;
 
+            try
+            {
                 Execute(enums, classDeclarations, referencedProjectClasses, callingPath, spc);
+            }
+            catch (Exception exception)
+            {
+                    Diagnostics.ReportException(spc, nameof(NgEnumsGenerator), exception);
+                }
             });
         }
 

--- a/Spiderly.SourceGenerators/Angular/NgTranslatesGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgTranslatesGenerator.cs
@@ -55,8 +55,14 @@ namespace Spiderly.SourceGenerators.Angular
             {
                 var (classesAndEntities, callingPath) = source;
                 var (classes, referencedClasses) = classesAndEntities;
-
-                Execute(classes, referencedClasses, callingPath, spc);
+                try
+                {
+                    Execute(classes, referencedClasses, callingPath, spc);
+                }
+                catch (Exception exception)
+                {
+                    Diagnostics.ReportException(spc, nameof(NgTranslatesGenerator), exception);
+                }
             });
         }
 

--- a/Spiderly.SourceGenerators/Angular/NgValidatorsGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgValidatorsGenerator.cs
@@ -55,7 +55,14 @@ namespace Spiderly.SourceGenerators.Angular
                 var (classesAndEntities, callingPath) = source;
                 var (classes, referencedClasses) = classesAndEntities;
 
-                Execute(classes, referencedClasses, callingPath, spc);
+                try
+                {
+                    Execute(classes, referencedClasses, callingPath, spc);
+                }
+                catch (Exception exception)
+                {
+                    Diagnostics.ReportException(spc, nameof(NgValidatorsGenerator), exception);
+                }
             });
         }
 

--- a/Spiderly.SourceGenerators/Shared/Diagnostics.cs
+++ b/Spiderly.SourceGenerators/Shared/Diagnostics.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Spiderly.SourceGenerators.Shared
+{
+    public static class Diagnostics
+    {
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            id: "SPDR0001",
+            title: "Unhandled error in Source Generator",
+            messageFormat: """Exception in '{0}':\n{1}""",
+            category: "Spiderly.SourceGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public static void ReportException(GeneratorExecutionContext context, string generatorName, Exception exception, Location location = null)
+        {
+            var diagnostic = Diagnostic.Create(
+                Descriptor,
+                location ?? Location.None,
+                generatorName,
+                exception.ToString());
+
+            context.ReportDiagnostic(diagnostic);
+        }
+        public static void ReportException(SourceProductionContext context, string generatorName, Exception exception, Location location = null)
+        {
+            var diagnostic = Diagnostic.Create(
+                Descriptor,
+                location ?? Location.None, 
+                generatorName, 
+                exception.ToString());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces basic error handling and diagnostic reporting for all source generators.

Key changes:
- Wrapped `Execute` method calls inside try-catch blocks in each generator.
- Added calls to `Diagnostics.ReportException` to report unhandled exceptions.
- This ensures that if any generator fails during execution, a useful diagnostic message is emitted during the build process.

Note: This is not the final implementation. The purpose of this PR is to confirm if I'm heading in the right direction with this diagnostic handling pattern before expanding further or polishing.

Please review and let me know if:
- The error handling structure aligns with our expectations
- There are improvements you'd suggest before I finalize and apply this pattern everywhere
<img width="1426" height="982" alt="image" src="https://github.com/user-attachments/assets/aa9dbd52-c28f-42d1-8fcf-2de4480fa09e" />

Thank You!!
Deepak Shirke