### PR TITLE
fix: Login verification codes use System.Random instead of a CSPRNG

### DIFF
--- a/Spiderly.Security/Services/JwtAuthManagerService.cs
+++ b/Spiderly.Security/Services/JwtAuthManagerService.cs
@@ -501,8 +501,7 @@ namespace Spiderly.Security.Services
 
         private static string GenerateVerificationCodeKey()
         {
-            int code = Random.Next(100000, 1000000);
-            return code.ToString("D6");
+            return RandomNumberGenerator.GetInt32(100000, 1000000).ToString("D6");
         }
 
         public virtual async Task RemoveLoginVerificationTokensByEmailAsync(string email)


### PR DESCRIPTION
Closes #393